### PR TITLE
feat(input.py,-config.json): ADD post_install step

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,0 +1,16 @@
+{
+  "version": "0.1.0",
+  "app": {
+    "version": "0.1.0",
+    "run": {
+      "command": ["bash", "run.sh"],
+      "interval": "10"
+    },
+    "env": {},
+    "platforms": ["linux", "darwin"],
+    "pre_install": [],
+    "post_install": ["python", "input.py"],
+    "pre_update": [],
+    "post_update": []
+  }
+}

--- a/input.py
+++ b/input.py
@@ -1,0 +1,65 @@
+import json
+
+ring_art = """                                                                                 
+                 ...                              
+              .::::::::..                         
+             ::.       ..:::.                     
+            .::          ..:-:.                   
+            :-:            ..--:                  
+           ..-:              .:::                 
+           ..:-:              .:::                
+            ..::               .::.               
+             ..::.             .:::               
+              ..--:             .::               
+               ..:::.           .-:               
+                 ..::..        .::                
+                   ...::::::.:::.                 
+                      .........                   
+                                                  
+###   ###   #  #   ##          ##   ####  ###   #  #  ###   
+#  #   #    ## #  #  #        #  #  #      #    #  #  #  #  
+#  #   #    ## #  #            #    ###    #    #  #  #  #  
+###    #    # ##  # ##          #   #      #    #  #  ###   
+# #    #    # ##  #  #        #  #  #      #    #  #  #     
+#  #  ###   #  #   ###         ##   ####   #     ##   #     
+                                                  
+"""
+
+# Define colors
+RED = "\033[0;31m"
+GREEN = "\033[0;32m"
+BLUE = "\033[0;34m"
+NC = "\033[0m"  # No Color
+
+# Display a beautiful prompt
+print(ring_art)
+
+# print(f"{BLUE}Please, fill the fields in order to setup your peer for the ring app:{NC}\n")
+is_lead = input(f"{BLUE}Will you be the leading this ring round (y/N)?{NC}")
+
+members = []
+if is_lead.lower() == "y":
+    leader = input(f"{BLUE}Add your email as a ring member: {NC}")
+    members.append(leader)
+    while True:
+        member = input(
+            f"{BLUE}Add new a ring member (Leave empty to stop adding peers): {NC}"
+        )
+        if not member:
+            break
+        members.append(member)
+
+    members.append(leader)
+
+secret_number = input(f"{BLUE}Secret Number: {NC}")
+
+
+# Write the secret number to a file
+with open("secret.txt", "w") as file:
+    file.write(secret_number)
+
+with open("data.json", "w") as file:
+    file.write(json.dumps({"ring": members, "data": 0, "current_index": 0}))
+
+# Confirm the action
+print(f"\n\n{GREEN}Everything has been set! Have good fun!{NC}\n\n")


### PR DESCRIPTION
This would allow users to setup secrets and ring members without having to write in a file

## Description
Please include a summary of the change, the motivation, and any additional context that will help others understand your PR. If it closes one or more open issues, [please tag them as described here](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
