### PR TITLE
Fix ring app not run with error `no module named syftbox` with python different than 3.12

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -5,6 +5,9 @@ set -e
 # this will create venv from python version defined in .python-version
 uv venv
 
+# Activate the virtual environment using the dot command
+. .venv/bin/activate
+
 # install requirements for the project
 uv pip install -r requirements.txt
 


### PR DESCRIPTION
Closes https://github.com/OpenMined/syft/issues/255


Reproduce: First, create a python 3.9 virtual env, then run `syftbox client` which will run the ring app with the error 
![image](https://github.com/user-attachments/assets/407e205f-1f4a-4935-b226-982e7adb8750)
Now go to the sync folder (e.g. `Desktop/SyftBox`), add a line to activate the sub-process's newly created env in the `apps/ring/run.sh`: 
![image](https://github.com/user-attachments/assets/8502c6bb-2198-46bb-81d7-dfad39361e03)
which will make the ring app runs
![image](https://github.com/user-attachments/assets/cc89ddf2-c2a0-43a1-a292-4ff344826f92)
